### PR TITLE
OCI specific changes for KP Flinkjobs 

### DIFF
--- a/kubernetes/ansible/roles/flink-jobs-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: template values.yaml file - checkpoint
+- name: template values.yaml file
   template:
     src: "{{ chart_path }}/values.j2"
     dest: "{{ chart_path }}/values.yaml"

--- a/kubernetes/ansible/roles/flink-jobs-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: template values.yaml file
+- name: template values.yaml file - checkpoint
   template:
     src: "{{ chart_path }}/values.j2"
     dest: "{{ chart_path }}/values.yaml"

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=AWS4SignerType",
+               "-Ds3.signing-algorithm=S3SignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,6 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=AWS3SignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -114,6 +114,7 @@ spec:
                "-Dpresto.s3.access-key={{ .Values.s3_access_key}}",
                "-Dpresto.s3.secret-key={{ .Values.s3_secret_key }}",
                "-Dpresto.s3.endpoint={{ .Values.s3_endpoint }}",
+               "-Dpresto.s3.region={{ .Values.s3_region }}",
                "-Dpresto.s3.path-style-access={{ .Values.s3_path_style_access }}",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.bucket.probe=0",
+               "-Ds3.bucket.probe=2",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -115,9 +115,9 @@ spec:
                "-Ds3.secret-key={{ .Values.s3_secret_key }}",
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access=true",
-               {{else}}
+               {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
-               {{end}}
+               {{- end}}
                "-Dweb.submit.enable=false",
                "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
                "-Dmetrics.reporter.prom.port={{ .Values.jobmanager.prom_port }}",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -110,7 +110,14 @@ spec:
         command: ["/opt/flink/bin/standalone-job.sh"]
         args: ["start-foreground",
                "--job-classname={{ .Values.job_classname }}", 
+               {{- if eq .Values.csp "oci" }}
+               "-Ds3.access-key={{ .Values.s3_access_key}}",
+               "-Ds3.secret-key={{ .Values.s3_secret_key }}",
+               "-Ds3.endpoint={{ .Values.s3_endpoint }}",
+               "-Ds3.path.style.access=true",
+               {{else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
+               {{end}}
                "-Dweb.submit.enable=false",
                "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
                "-Dmetrics.reporter.prom.port={{ .Values.jobmanager.prom_port }}",
@@ -183,7 +190,14 @@ spec:
         workingDir: {{ .Values.taskmanager.flink_work_dir }}
         command: ["/opt/flink/bin/taskmanager.sh"]
         args: ["start-foreground",
+          {{- if eq .Values.csp "oci" }}
+          "-Ds3.access-key={{ .Values.s3_access_key}}",
+          "-Ds3.secret-key={{ .Values.s3_secret_key }}",
+          "-Ds3.endpoint={{ .Values.s3_endpoint }}",
+          "-Ds3.path.style.access=true",
+          {{else}}
           "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
+          {{end}}
           "-Dweb.submit.enable=false",
           "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
           "-Dmetrics.reporter.prom.host={{ .Release.Name }}-taskmanager",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -114,7 +114,6 @@ spec:
                "-Ds3.access.key={{ .Values.s3_access_key}}",
                "-Ds3.secret.key={{ .Values.s3_secret_key }}",
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-               "-Ds3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=NoOpSignerType",
+               "-Ds3.signing-algorithm=S3SignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -111,10 +111,10 @@ spec:
         args: ["start-foreground",
                "--job-classname={{ .Values.job_classname }}",
                {{- if eq .Values.csp "oci" }}
-               "-Dfs.s3.access.key={{ .Values.s3_access_key}}",
-               "-Dfs.s3.secret.key={{ .Values.s3_secret_key }}",
-               "-Dfs.s3.endpoint={{ .Values.s3_endpoint }}",
-               "-Dfs.s3.path.style.access=true",
+               "-Dfs.s3a.access.key={{ .Values.s3_access_key}}",
+               "-Dfs.s3a.secret.key={{ .Values.s3_secret_key }}",
+               "-Dfs.s3a.endpoint={{ .Values.s3_endpoint }}",
+               "-Dfs.s3a.path.style.access=true",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -115,6 +115,7 @@ spec:
                "-Ds3.secret.key={{ .Values.s3_secret_key }}",
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
+               "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=AWS4SignerType",
+               "-Ds3.signing-algorithm=AWS4UnsignedPayloadSignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.bucket.probe=0",
+               "-Ds3.endpoint.region={{ .Values.s3_region }}",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -114,7 +114,7 @@ spec:
                "-Ds3.access.key={{ .Values.s3_access_key}}",
                "-Ds3.secret.key={{ .Values.s3_secret_key }}",
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-               "-Ds3.path.style.access=true",
+               "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -114,6 +114,7 @@ spec:
                "-Ds3.access.key={{ .Values.s3_access_key}}",
                "-Ds3.secret.key={{ .Values.s3_secret_key }}",
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
+               "-Ds3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.bucket.probe=1",
+               "-Ds3.bucket.probe=0",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -110,14 +110,7 @@ spec:
         command: ["/opt/flink/bin/standalone-job.sh"]
         args: ["start-foreground",
                "--job-classname={{ .Values.job_classname }}", 
-               {{- if eq .Values.csp "oci" }}
-               "-Ds3.access-key={{ .Values.s3_access_key}}",
-               "-Ds3.secret-key={{ .Values.s3_secret_key }}",
-               "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-               "-Ds3.path.style.access=true",
-               {{else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
-               {{end}}
                "-Dweb.submit.enable=false",
                "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
                "-Dmetrics.reporter.prom.port={{ .Values.jobmanager.prom_port }}",
@@ -190,14 +183,7 @@ spec:
         workingDir: {{ .Values.taskmanager.flink_work_dir }}
         command: ["/opt/flink/bin/taskmanager.sh"]
         args: ["start-foreground",
-          {{- if eq .Values.csp "oci" }}
-          "-Ds3.access-key={{ .Values.s3_access_key}}",
-          "-Ds3.secret-key={{ .Values.s3_secret_key }}",
-          "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-          "-Ds3.path.style.access=true",
-          {{else}}
           "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
-          {{end}}
           "-Dweb.submit.enable=false",
           "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
           "-Dmetrics.reporter.prom.host={{ .Release.Name }}-taskmanager",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -111,12 +111,10 @@ spec:
         args: ["start-foreground",
                "--job-classname={{ .Values.job_classname }}",
                {{- if eq .Values.csp "oci" }}
-               "-Ds3.access.key={{ .Values.s3_access_key}}",
-               "-Ds3.secret.key={{ .Values.s3_secret_key }}",
-               "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-               "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
-               "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.endpoint.region={{ .Values.s3_region }}",
+               "-Dpresto.s3.access-key={{ .Values.s3_access_key}}",
+               "-Dpresto.s3.secret-key={{ .Values.s3_secret_key }}",
+               "-Dpresto.s3.endpoint={{ .Values.s3_endpoint }}",
+               "-Dpresto.s3.path-style-access={{ .Values.s3_path_style_access }}",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,6 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
+               "-Ds3.bucket.probe=0",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,6 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
+               "-Ds3.signing-algorithm=AWS4SignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -190,7 +190,14 @@ spec:
         workingDir: {{ .Values.taskmanager.flink_work_dir }}
         command: ["/opt/flink/bin/taskmanager.sh"]
         args: ["start-foreground",
+          {{- if eq .Values.csp "oci" }}
+          "-Ds3.access-key={{ .Values.s3_access_key}}",
+          "-Ds3.secret-key={{ .Values.s3_secret_key }}",
+          "-Ds3.endpoint={{ .Values.s3_endpoint }}",
+          "-Ds3.path.style.access=true",
+          {{- else}}
           "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
+          {{- end}}
           "-Dweb.submit.enable=false",
           "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
           "-Dmetrics.reporter.prom.host={{ .Release.Name }}-taskmanager",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -109,8 +109,15 @@ spec:
         workingDir: /opt/flink
         command: ["/opt/flink/bin/standalone-job.sh"]
         args: ["start-foreground",
-               "--job-classname={{ .Values.job_classname }}", 
+               "--job-classname={{ .Values.job_classname }}",
+               {{- if eq .Values.csp "oci" }}
+               "-Ds3.access-key={{ .Values.s3_access_key}}",
+               "-Ds3.secret-key={{ .Values.s3_secret_key }}",
+               "-Ds3.endpoint={{ .Values.s3_endpoint }}",
+               "-Ds3.path.style.access=true",
+               {{else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
+               {{end}}
                "-Dweb.submit.enable=false",
                "-Dmetrics.reporter.prom.class=org.apache.flink.metrics.prometheus.PrometheusReporter",
                "-Dmetrics.reporter.prom.port={{ .Values.jobmanager.prom_port }}",

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.bucket.probe=2",
+               "-Ds3.bucket.probe=1",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=AWS4UnsignedPayloadSignerType",
+               "-Ds3.signing-algorithm=NoOpSignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -111,10 +111,10 @@ spec:
         args: ["start-foreground",
                "--job-classname={{ .Values.job_classname }}",
                {{- if eq .Values.csp "oci" }}
-               "-Dfs.s3a.access.key={{ .Values.s3_access_key}}",
-               "-Dfs.s3a.secret.key={{ .Values.s3_secret_key }}",
-               "-Dfs.s3a.endpoint={{ .Values.s3_endpoint }}",
-               "-Dfs.s3a.path.style.access=true",
+               "-Ds3.access.key={{ .Values.s3_access_key}}",
+               "-Ds3.secret.key={{ .Values.s3_secret_key }}",
+               "-Ds3.endpoint={{ .Values.s3_endpoint }}",
+               "-Ds3.path.style.access=true",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,6 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=S3SignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,7 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.signing-algorithm=S3SignerType",
+               "-Ds3.signing-algorithm=AWS3SignerType",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -192,10 +192,11 @@ spec:
         command: ["/opt/flink/bin/taskmanager.sh"]
         args: ["start-foreground",
           {{- if eq .Values.csp "oci" }}
-          "-Dfs.s3.access.key={{ .Values.s3_access_key}}",
-          "-Dfs.s3.secret.key={{ .Values.s3_secret_key }}",
-          "-Dfs.s3.endpoint={{ .Values.s3_endpoint }}",
-          "-Dfs.s3.path.style.access=true",
+          "-Dpresto.s3.access.key={{ .Values.s3_access_key}}",
+          "-Dpresto.s3.secret.key={{ .Values.s3_secret_key }}",
+          "-Dpresto.s3.endpoint={{ .Values.s3_endpoint }}",
+          "-Dpresto.s3.endpoint={{ .Values.s3_region }}",
+          "-Dpresto.s3.path.style.access={{ .Values.s3_path_style_access }}",
           {{- else}}
           "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
           {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -111,10 +111,10 @@ spec:
         args: ["start-foreground",
                "--job-classname={{ .Values.job_classname }}",
                {{- if eq .Values.csp "oci" }}
-               "-Ds3.access-key={{ .Values.s3_access_key}}",
-               "-Ds3.secret-key={{ .Values.s3_secret_key }}",
-               "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-               "-Ds3.path.style.access=true",
+               "-Dfs.s3.access.key={{ .Values.s3_access_key}}",
+               "-Dfs.s3.secret.key={{ .Values.s3_secret_key }}",
+               "-Dfs.s3.endpoint={{ .Values.s3_endpoint }}",
+               "-Dfs.s3.path.style.access=true",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}
@@ -191,10 +191,10 @@ spec:
         command: ["/opt/flink/bin/taskmanager.sh"]
         args: ["start-foreground",
           {{- if eq .Values.csp "oci" }}
-          "-Ds3.access-key={{ .Values.s3_access_key}}",
-          "-Ds3.secret-key={{ .Values.s3_secret_key }}",
-          "-Ds3.endpoint={{ .Values.s3_endpoint }}",
-          "-Ds3.path.style.access=true",
+          "-Dfs.s3.access.key={{ .Values.s3_access_key}}",
+          "-Dfs.s3.secret.key={{ .Values.s3_secret_key }}",
+          "-Dfs.s3.endpoint={{ .Values.s3_endpoint }}",
+          "-Dfs.s3.path.style.access=true",
           {{- else}}
           "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
           {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
+++ b/kubernetes/helm_charts/datapipeline_jobs/templates/flink_job_deployment.yaml
@@ -116,7 +116,6 @@ spec:
                "-Ds3.endpoint={{ .Values.s3_endpoint }}",
                "-Ds3.path.style.access={{ .Values.s3_path_style_access }}",
                "-Ds3.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-               "-Ds3.bucket.probe=0",
                {{- else}}
                "-Dfs.azure.account.key.{{ .Values.azure_account }}.blob.core.windows.net={{ .Values.azure_secret }}",
                {{- end}}

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -517,9 +517,7 @@ asset-enrichment:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
-    s3.access.key: {{ cloud_public_storage_accountname }}
-    s3.secret.key: {{cloud_public_storage_secret}}
+
 
 audit-history-indexer:
   audit-history-indexer: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -62,8 +62,7 @@ log4j_console_properties: |
   logger.hadoop.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
   logger.zookeeper.level = {{ flink_libraries_log_level | default(INFO) }}
-  logger.http.name = org.apache.http
-  logger.http.level = {{ flink_libraries_log_level | default(INFO) }}
+
 
 
   # Log all infos to the console

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -62,6 +62,10 @@ log4j_console_properties: |
   logger.hadoop.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
   logger.zookeeper.level = {{ flink_libraries_log_level | default(INFO) }}
+  logger.aws.name = com.amazonaws.request
+  logger.aws.level = {{ flink_libraries_log_level | default(INFO) }}
+  logger.awshttp.name = com.amazonaws.thirdparty.apache.http
+  logger.awshttp.level = {{ flink_libraries_log_level | default(INFO) }}
 
   # Log all infos to the console
   appender.console.name = ConsoleAppender

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -310,14 +310,13 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    fs.s3.access.key: {{cloud_public_storage_accountname}}
-    fs.s3.secret.key: {{cloud_public_storage_secret}}
-    fs.s3.path.style.access: true
+    hive.s3.aws-access-key: {{cloud_public_storage_accountname}}
+    hive.s3.aws-secret-key: {{cloud_public_storage_secret}}
+    hive.s3.path-style-access: true
 {% if cloud_service_provider == "oci" %}
-    fs.s3.endpoint: {{oci_flink_s3_storage_endpoint}}
-    fs.s3.endpoint.region: {{s3_region}}
+    hive.s3.endpoint: {{oci_flink_s3_storage_endpoint}}
 {% else %}
-    fs.s3.endpoint: {{cloud_public_storage_endpoint}}
+    hive.s3.endpoint: {{cloud_public_storage_endpoint}}
 {% endif %}
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -271,11 +271,11 @@ questionset-publish:
       table = "questionset_hierarchy"
     }
     print_service.base_url = "{{ kp_print_service_base_url }}"
-{% if cloud_service_provider == "oci" -%}
+{%- if cloud_service_provider == "oci" %}
     cloud_storage_type="{{ oci_flink_storage_type }}"
-{% else -%}
+{%- else %}
     cloud_storage_type="{{ cloud_service_provider }}"
-{% endif %}
+{%- endif %}
     cloud_storage_type="{{ cloud_service_provider }}"
     cloud_storage_key="{{ cloud_public_storage_accountname }}"
     cloud_storage_secret="{{ cloud_public_storage_secret }}"

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -310,13 +310,14 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    hive.s3.aws-access-key: {{cloud_public_storage_accountname}}
-    hive.s3.aws-secret-key: {{cloud_public_storage_secret}}
-    hive.s3.path-style-access: true
+    fs.s3.access.key: {{cloud_public_storage_accountname}}
+    fs.s3.secret.key: {{cloud_public_storage_secret}}
+    fs.s3.path.style.access: true
 {% if cloud_service_provider == "oci" %}
-    hive.s3.endpoint: {{oci_flink_s3_storage_endpoint}}
+    fs.s3.endpoint: {{oci_flink_s3_storage_endpoint}}
+    fs.s3.endpoint.region: {{s3_region}}
 {% else %}
-    hive.s3.endpoint: {{cloud_public_storage_endpoint}}
+    fs.s3.endpoint: {{cloud_public_storage_endpoint}}
 {% endif %}
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -307,9 +307,6 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    fs.s3.access.key: {{ cloud_public_storage_accountname }}
-    fs.s3.secret.key:  {{cloud_public_storage_secret}}
-    fs.s3.endpoint: {{cloud_public_storage_endpoint}}
 
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -310,15 +310,7 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    s3.access.key: {{cloud_public_storage_accountname}}
-    s3.secret.key: {{cloud_public_storage_secret}}
-    s3.path.style.access: true
-{% if cloud_service_provider == "oci" %}
-    s3.endpoint: {{oci_flink_s3_storage_endpoint}}
-    s3.endpoint.region: {{s3_region}}
-{% else %}
-    s3.endpoint: {{cloud_public_storage_endpoint}}
-{% endif %}
+
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -301,6 +301,7 @@ questionset-publish:
     cloud_storage_container="{{ cloud_storage_content_bucketname }}"
     cloud_storage_endpoint="{{cloudstorage_sdk_endpoint}}"
 
+
     master.category.validation.enabled ="{{ master_category_validation_enabled }}"
 
   flink-conf: |+
@@ -310,6 +311,7 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
+    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -10,6 +10,8 @@ s3_access_key: {{ cloud_public_storage_accountname }}
 s3_secret_key: {{cloud_public_storage_secret}}
 {% if cloud_service_provider == "oci" %}
 s3_endpoint: {{oci_flink_s3_storage_endpoint}}
+s3_region: {{s3_region}}
+s3_path_style_access: true
 {% else %}
 s3_endpoint: {{cloud_public_storage_endpoint}}
 {% endif %}
@@ -308,6 +310,11 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
+    fs.s3.access.key: {{s3_access_key}}
+    fs.s3.secret.key: {{s3_secret_key}}
+    fs.s3.endpoint: {{s3_endpoint}}
+    fs.s3.endpoint.region: {{s3_region}}
+    fs.s3.path.style.access: {{s3_path_style_access}}
 
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -3,8 +3,12 @@ imagepullsecrets: {{ imagepullsecrets }}
 dockerhub: {{ dockerhub }}
 repository: {{flink_repository|default('knowledge-platform-jobs')}}
 image_tag: {{ image_tag }}
+csp: {{cloud_service_provider}}
 azure_account: {{ azure_account }}
 azure_secret: {{ azure_secret }}
+s3_access_key: {{ cloud_public_storage_accountname }}
+s3_secret_key: {{cloud_public_storage_secret}}
+s3_endpoint: {{cloud_public_storage_endpoint}}
 serviceMonitor:
   enabled: {{ service_monitor_enabled | lower}}
 

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -62,10 +62,9 @@ log4j_console_properties: |
   logger.hadoop.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
   logger.zookeeper.level = {{ flink_libraries_log_level | default(INFO) }}
-  logger.aws.name = com.amazonaws.request
-  logger.aws.level = {{ flink_libraries_log_level | default(INFO) }}
-  logger.awshttp.name = com.amazonaws.thirdparty.apache.http
-  logger.awshttp.level = {{ flink_libraries_log_level | default(INFO) }}
+  logger.http.name = org.apache.http
+  logger.http.level = {{ flink_libraries_log_level | default(INFO) }}
+
 
   # Log all infos to the console
   appender.console.name = ConsoleAppender

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -315,7 +315,7 @@ questionset-publish:
     s3.secret.key: {{cloud_public_storage_secret}}
     s3.endpoint: {{oci_flink_s3_storage_endpoint}}
     s3.path.style.access: true
-    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.BasicAWSCredentialsProvider
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -310,12 +310,15 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    fs.s3.access.key: {{s3_access_key}}
-    fs.s3.secret.key: {{s3_secret_key}}
-    fs.s3.endpoint: {{s3_endpoint}}
+    fs.s3.access.key: {{cloud_public_storage_accountname}}
+    fs.s3.secret.key: {{cloud_public_storage_secret}}
+    fs.s3.path.style.access: true
+{% if cloud_service_provider == "oci" %}
+    fs.s3.endpoint: {{oci_flink_s3_storage_endpoint}}
     fs.s3.endpoint.region: {{s3_region}}
-    fs.s3.path.style.access: {{s3_path_style_access}}
-
+{% else %}
+    fs.s3.endpoint: {{cloud_public_storage_endpoint}}
+{% endif %}
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -518,6 +518,8 @@ asset-enrichment:
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
     s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+    s3.access.key: {{ cloud_public_storage_accountname }}
+    s3.secret.key: {{cloud_public_storage_secret}}
 
 audit-history-indexer:
   audit-history-indexer: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -315,6 +315,7 @@ questionset-publish:
     s3.secret.key: {{cloud_public_storage_secret}}
     s3.endpoint: {{oci_flink_s3_storage_endpoint}}
     s3.path.style.access: true
+    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -271,11 +271,11 @@ questionset-publish:
       table = "questionset_hierarchy"
     }
     print_service.base_url = "{{ kp_print_service_base_url }}"
-{%- if cloud_service_provider == "oci" %}
+{% if cloud_service_provider == "oci" %}
     cloud_storage_type="{{ oci_flink_storage_type }}"
-{%- else %}
+{% else %}
     cloud_storage_type="{{ cloud_service_provider }}"
-{%- endif %}
+{% endif %}
     cloud_storage_type="{{ cloud_service_provider }}"
     cloud_storage_key="{{ cloud_public_storage_accountname }}"
     cloud_storage_secret="{{ cloud_public_storage_secret }}"

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -93,7 +93,7 @@ base_config: |
             checkpointing.dir = "checkpoint"
           }
         }
-        base.url = "s3://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.checkpointing.dir}
+        base.url = "s3a://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.checkpointing.dir}
       }
 {% else %}
       statebackend {

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -78,7 +78,7 @@ base_config: |
     job {
       env = "{{ env_name }}"
       enable.distributed.checkpointing = true
-      {{- if eq .Values.csp "oci" }}
+{% if cloud_service_provider == "oci" %}
       statebackend {
         s3 {
           storage {
@@ -89,7 +89,7 @@ base_config: |
         }
         base.url = "s3://"${job.statebackend.blob.storage.container}"/"${job.statebackend.s3.storage.endpoint}
       }
-      {{- else }}
+{% else %}
       statebackend {
         blob {
           storage {
@@ -100,7 +100,7 @@ base_config: |
         }
         base.url = "wasbs://"${job.statebackend.blob.storage.container}"@"${job.statebackend.blob.storage.account}"/"${job.statebackend.blob.storage.checkpointing.dir}
       }
-      {{- end}}
+{% endif %}
 
     }
     task {

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -517,6 +517,7 @@ asset-enrichment:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
+    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 
 audit-history-indexer:
   audit-history-indexer: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -311,7 +311,10 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-
+    s3.access.key: {{ cloud_public_storage_accountname }}
+    s3.secret.key: {{cloud_public_storage_secret}}
+    s3.endpoint: {{oci_flink_s3_storage_endpoint}}
+    s3.path.style.access: true
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -271,6 +271,11 @@ questionset-publish:
       table = "questionset_hierarchy"
     }
     print_service.base_url = "{{ kp_print_service_base_url }}"
+{% if cloud_service_provider == "oci" -%}
+    cloud_storage_type="{{ oci_flink_storage_type }}"
+{% else -%}
+    cloud_storage_type="{{ cloud_service_provider }}"
+{% endif %}
     cloud_storage_type="{{ cloud_service_provider }}"
     cloud_storage_key="{{ cloud_public_storage_accountname }}"
     cloud_storage_secret="{{ cloud_public_storage_secret }}"

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -315,7 +315,6 @@ questionset-publish:
     s3.secret.key: {{cloud_public_storage_secret}}
     s3.endpoint: {{oci_flink_s3_storage_endpoint}}
     s3.path.style.access: true
-    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.BasicAWSCredentialsProvider
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -93,7 +93,7 @@ base_config: |
             checkpointing.dir = "checkpoint"
           }
         }
-        base.url = "s3a://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.checkpointing.dir}
+        base.url = "s3://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.checkpointing.dir}
       }
 {% else %}
       statebackend {

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -310,14 +310,14 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    fs.s3.access.key: {{cloud_public_storage_accountname}}
-    fs.s3.secret.key: {{cloud_public_storage_secret}}
-    fs.s3.path.style.access: true
+    s3.access.key: {{cloud_public_storage_accountname}}
+    s3.secret.key: {{cloud_public_storage_secret}}
+    s3.path.style.access: true
 {% if cloud_service_provider == "oci" %}
-    fs.s3.endpoint: {{oci_flink_s3_storage_endpoint}}
-    fs.s3.endpoint.region: {{s3_region}}
+    s3.endpoint: {{oci_flink_s3_storage_endpoint}}
+    s3.endpoint.region: {{s3_region}}
 {% else %}
-    fs.s3.endpoint: {{cloud_public_storage_endpoint}}
+    s3.endpoint: {{cloud_public_storage_endpoint}}
 {% endif %}
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -293,7 +293,7 @@ questionset-publish:
       table = "questionset_hierarchy"
     }
     print_service.base_url = "{{ kp_print_service_base_url }}"
-    cloud_service_provider="{{cloud_service_provider}}
+    cloud_service_provider="{{cloud_service_provider}}"
     cloud_storage_key="{{ cloud_public_storage_accountname }}"
     cloud_storage_secret="{{ cloud_public_storage_secret }}"
     cloud_storage_container="{{ cloud_storage_content_bucketname }}"

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -311,7 +311,6 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    s3.aws.credentials.provider: org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 
 
 video-stream-generator:

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -300,7 +300,6 @@ questionset-publish:
     cloud_storage_secret="{{ cloud_public_storage_secret }}"
     cloud_storage_container="{{ cloud_storage_content_bucketname }}"
     cloud_storage_endpoint="{{cloudstorage_sdk_endpoint}}"
-    hive.s3.path-style-access=true
 
     master.category.validation.enabled ="{{ master_category_validation_enabled }}"
 

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -307,6 +307,10 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
+    fs.s3.access.key: {{ cloud_public_storage_accountname }}
+    fs.s3.secret.key:  {{cloud_public_storage_secret}}
+    fs.s3.endpoint: {{cloud_public_storage_endpoint}}
+
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -276,7 +276,6 @@ questionset-publish:
 {% else %}
     cloud_storage_type="{{ cloud_service_provider }}"
 {% endif %}
-    cloud_storage_type="{{ cloud_service_provider }}"
     cloud_storage_key="{{ cloud_public_storage_accountname }}"
     cloud_storage_secret="{{ cloud_public_storage_secret }}"
     cloud_storage_container="{{ cloud_storage_content_bucketname }}"

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -293,14 +293,11 @@ questionset-publish:
       table = "questionset_hierarchy"
     }
     print_service.base_url = "{{ kp_print_service_base_url }}"
-{% if cloud_service_provider == "oci" %}
-    cloud_storage_type="{{ oci_flink_storage_type }}"
-{% else %}
-    cloud_storage_type="{{ cloud_service_provider }}"
-{% endif %}
+    cloud_service_provider="{{cloud_service_provider}}
     cloud_storage_key="{{ cloud_public_storage_accountname }}"
     cloud_storage_secret="{{ cloud_public_storage_secret }}"
     cloud_storage_container="{{ cloud_storage_content_bucketname }}"
+    cloud_storage_endpoint="{{cloudstorage_sdk_endpoint}}"
 
     master.category.validation.enabled ="{{ master_category_validation_enabled }}"
 

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -48,8 +48,8 @@ log4j_console_properties: |
   rootLogger.appenderRef.console.ref = ConsoleAppender
 
   # Uncomment this if you want to _only_ change Flink's logging
-  #logger.flink.name = org.apache.flink
-  #logger.flink.level = {{ flink_jobs_console_log_level | default(INFO) }}
+  logger.flink.name = org.apache.flink
+  logger.flink.level = {{ flink_jobs_console_log_level | default(INFO) }}
 
   # The following lines keep the log level of common libraries/connectors on
   # log level INFO. The root logger does not override this. You have to manually
@@ -62,8 +62,7 @@ log4j_console_properties: |
   logger.hadoop.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
   logger.zookeeper.level = {{ flink_libraries_log_level | default(INFO) }}
-  logger.http.name = org.apache.http
-  logger.http.level = {{ flink_libraries_log_level | default(INFO) }}
+
 
 
   # Log all infos to the console

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -300,6 +300,7 @@ questionset-publish:
     cloud_storage_secret="{{ cloud_public_storage_secret }}"
     cloud_storage_container="{{ cloud_storage_content_bucketname }}"
     cloud_storage_endpoint="{{cloudstorage_sdk_endpoint}}"
+    hive.s3.path-style-access=true
 
     master.category.validation.enabled ="{{ master_category_validation_enabled }}"
 

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -313,10 +313,7 @@ questionset-publish:
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
     taskmanager.memory.network.fraction: 0.1
-    s3.access.key: {{ cloud_public_storage_accountname }}
-    s3.secret.key: {{cloud_public_storage_secret}}
-    s3.endpoint: {{oci_flink_s3_storage_endpoint}}
-    s3.path.style.access: true
+
 
 video-stream-generator:
   video-stream-generator: |+

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -87,7 +87,7 @@ base_config: |
             checkpointing.dir = "checkpoint"
           }
         }
-        base.url = "s3://"${job.statebackend.blob.storage.container}"/"${job.statebackend.s3.storage.endpoint}
+        base.url = "s3://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.endpoint}
       }
 {% else %}
       statebackend {

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -48,8 +48,8 @@ log4j_console_properties: |
   rootLogger.appenderRef.console.ref = ConsoleAppender
 
   # Uncomment this if you want to _only_ change Flink's logging
-  logger.flink.name = org.apache.flink
-  logger.flink.level = {{ flink_jobs_console_log_level | default(INFO) }}
+  # logger.flink.name = org.apache.flink
+  # logger.flink.level = {{ flink_jobs_console_log_level | default(INFO) }}
 
   # The following lines keep the log level of common libraries/connectors on
   # log level INFO. The root logger does not override this. You have to manually
@@ -62,7 +62,8 @@ log4j_console_properties: |
   logger.hadoop.level = {{ flink_libraries_log_level | default(INFO) }}
   logger.zookeeper.name = org.apache.zookeeper
   logger.zookeeper.level = {{ flink_libraries_log_level | default(INFO) }}
-
+  logger.http.name = org.apache.http
+  logger.http.level = {{ flink_libraries_log_level | default(INFO) }}
 
 
   # Log all infos to the console

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -8,7 +8,11 @@ azure_account: {{ azure_account }}
 azure_secret: {{ azure_secret }}
 s3_access_key: {{ cloud_public_storage_accountname }}
 s3_secret_key: {{cloud_public_storage_secret}}
+{% if cloud_service_provider == "oci" %}
+s3_endpoint: {{oci_flink_s3_storage_endpoint}}
+{% else %}
 s3_endpoint: {{cloud_public_storage_endpoint}}
+{% endif %}
 serviceMonitor:
   enabled: {{ service_monitor_enabled | lower}}
 
@@ -82,12 +86,12 @@ base_config: |
       statebackend {
         s3 {
           storage {
-            endpoint = "{{ cloud_public_storage_endpoint }}"
+            endpoint = "{{ oci_flink_s3_storage_endpoint }}"
             container = "{{ flink_container_name }}"
             checkpointing.dir = "checkpoint"
           }
         }
-        base.url = "s3://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.endpoint}
+        base.url = "s3://"${job.statebackend.s3.storage.container}"/"${job.statebackend.s3.storage.checkpointing.dir}
       }
 {% else %}
       statebackend {

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -78,6 +78,18 @@ base_config: |
     job {
       env = "{{ env_name }}"
       enable.distributed.checkpointing = true
+      {{- if eq .Values.csp "oci" }}
+      statebackend {
+        s3 {
+          storage {
+            endpoint = "{{ cloud_public_storage_endpoint }}"
+            container = "{{ flink_container_name }}"
+            checkpointing.dir = "checkpoint"
+          }
+        }
+        base.url = "s3://"${job.statebackend.blob.storage.container}"/"${job.statebackend.s3.storage.endpoint}
+      }
+      {{- else }}
       statebackend {
         blob {
           storage {
@@ -88,6 +100,8 @@ base_config: |
         }
         base.url = "wasbs://"${job.statebackend.blob.storage.container}"@"${job.statebackend.blob.storage.account}"/"${job.statebackend.blob.storage.checkpointing.dir}
       }
+      {{- end}}
+
     }
     task {
       parallelism = 1


### PR DESCRIPTION
The main changes done is to make kp flinkjobs talk to OCI object storage using s3 compliant api

1) Added the switch to select the startup flag ( presto) for starting jobmanager and taskmanager
2) Defined the state backend for s3 
3) added cloudstorage endpoint for interacting with sunbird cloud storage sdk